### PR TITLE
Expand derived Clone for Buffer to avoid unnecessary where clause

### DIFF
--- a/src/exttypes/buffer.rs
+++ b/src/exttypes/buffer.rs
@@ -5,13 +5,24 @@ use crate::{rpc::model::IntoVal, Neovim};
 /// A struct representing a neovim buffer. It is specific to a
 /// [`Neovim`](crate::neovim::Neovim) instance, and calling a method on it will
 /// always use this instance.
-#[derive(Clone)]
 pub struct Buffer<W>
 where
   W: AsyncWrite + Send + Unpin + 'static,
 {
   pub(crate) code_data: Value,
   pub(crate) neovim: Neovim<W>,
+}
+
+impl<W> Clone for Buffer<W>
+  where
+  W: AsyncWrite + Send + Unpin + 'static
+{
+  fn clone(&self) -> Self {
+    Self {
+      code_data: self.code_data.clone(),
+      neovim: self.neovim.clone(),
+    }
+  }
 }
 
 impl<W> IntoVal<Value> for &Buffer<W>


### PR DESCRIPTION
With that change it doesn't matter if `W` implements `Clone` or not. 

**Licensing**: The code contributed to nvim-rs is licensed under the MIT or
Apache license as given in the project root directory.
