### PR TITLE
Hide Value from user and use serde instead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "byteorder"
-version = "1.3.2"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
+checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
 
 [[package]]
 name = "bytes"
@@ -643,7 +643,9 @@ dependencies = [
  "log",
  "neovim-lib",
  "rmp",
+ "rmp-serde",
  "rmpv",
+ "serde",
  "tempdir",
  "tokio",
  "tokio-util",
@@ -717,9 +719,9 @@ checksum = "369a6ed065f249a159e06c45752c780bda2fb53c995718f9e484d08daa9eb42e"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.7"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0319972dcae462681daf4da1adeeaa066e3ebd29c69be96c6abb1259d2ee2bcc"
+checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
  "unicode-xid",
 ]
@@ -857,6 +859,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmp-serde"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "839395ef53057db96b84c9238ab29e1a13f2e5c8ec9f66bef853ab4197303924"
+dependencies = [
+ "byteorder",
+ "rmp",
+ "serde",
+]
+
+[[package]]
 name = "rmpv"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -915,9 +928,12 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.104"
+version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
+checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_bytes"
@@ -930,9 +946,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.104"
+version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
+checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -984,9 +1000,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.13"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4ff033220a41d1a57d8125eab57bf5263783dfdcc18688b1dacc6ce9651ef8"
+checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ bench = false
 
 [dependencies]
 rmp = "0.8.9"
-rmpv = "0.4.3"
+rmpv = { version = "0.4.3", features = ["with-serde"] }
 log = "0.4.8"
 async-trait = "0.1.22"
 futures = { version = "0.3.1", features = ["io-compat"] }
@@ -37,6 +37,8 @@ tokio = { version = "1.1.1", features = ["full"] , optional = true}
 tokio-util = { version = "0.6.3", features = ["compat"], optional = true }
 async-std = { version = "1.4.0", features = ["attributes"], optional = true }
 neovim-lib = { version = "0.6.1", optional = true }
+serde = { version = "1.0.123", features = ["derive"] }
+rmp-serde = "0.15.4"
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/src/error.rs
+++ b/src/error.rs
@@ -168,6 +168,7 @@ pub enum EncodeError {
   /// Encoding the message into the internal buffer has failed.
   BufferError(RmpvEncodeError),
   SerdeBufferError(rmp_serde::encode::Error),
+  ToValueError(rmpv::ext::Error),
   /// Writing the encoded message to the stream failed.
   WriterError(io::Error),
 }
@@ -176,6 +177,7 @@ impl Error for EncodeError {
   fn source(&self) -> Option<&(dyn Error + 'static)> {
     match *self {
       EncodeError::BufferError(ref e) => Some(e),
+      EncodeError::ToValueError(ref e) => Some(e),
       EncodeError::SerdeBufferError(ref e) => Some(e),
       EncodeError::WriterError(ref e) => Some(e),
     }
@@ -187,6 +189,7 @@ impl Display for EncodeError {
     let s = match *self {
       Self::BufferError(_) => "Error writing to buffer",
       Self::SerdeBufferError(_) => "Error writing to buffer using serde",
+      Self::ToValueError(_) => "Error converting serializable to Value",
       Self::WriterError(_) => "Error writing to the Writer",
     };
 
@@ -197,6 +200,12 @@ impl Display for EncodeError {
 impl From<RmpvEncodeError> for Box<EncodeError> {
   fn from(err: RmpvEncodeError) -> Box<EncodeError> {
     Box::new(EncodeError::BufferError(err))
+  }
+}
+
+impl From<rmpv::ext::Error> for Box<EncodeError> {
+  fn from(err: rmpv::ext::Error) -> Box<EncodeError> {
+    Box::new(EncodeError::ToValueError(err))
   }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -167,6 +167,7 @@ impl From<io::Error> for Box<DecodeError> {
 pub enum EncodeError {
   /// Encoding the message into the internal buffer has failed.
   BufferError(RmpvEncodeError),
+  SerdeBufferError(rmp_serde::encode::Error),
   /// Writing the encoded message to the stream failed.
   WriterError(io::Error),
 }
@@ -175,6 +176,7 @@ impl Error for EncodeError {
   fn source(&self) -> Option<&(dyn Error + 'static)> {
     match *self {
       EncodeError::BufferError(ref e) => Some(e),
+      EncodeError::SerdeBufferError(ref e) => Some(e),
       EncodeError::WriterError(ref e) => Some(e),
     }
   }
@@ -184,6 +186,7 @@ impl Display for EncodeError {
   fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
     let s = match *self {
       Self::BufferError(_) => "Error writing to buffer",
+      Self::SerdeBufferError(_) => "Error writing to buffer using serde",
       Self::WriterError(_) => "Error writing to the Writer",
     };
 
@@ -194,6 +197,12 @@ impl Display for EncodeError {
 impl From<RmpvEncodeError> for Box<EncodeError> {
   fn from(err: RmpvEncodeError) -> Box<EncodeError> {
     Box::new(EncodeError::BufferError(err))
+  }
+}
+
+impl From<rmp_serde::encode::Error> for Box<EncodeError> {
+  fn from(err: rmp_serde::encode::Error) -> Self {
+    Box::new(EncodeError::SerdeBufferError(err))
   }
 }
 

--- a/src/neovim.rs
+++ b/src/neovim.rs
@@ -1,5 +1,6 @@
 //! An active neovim session.
 use std::{
+  fmt,
   future::Future,
   sync::{
     atomic::{AtomicU64, Ordering},
@@ -23,13 +24,19 @@ use crate::{
   },
   uioptions::UiAttachOptions,
 };
-use rmpv::Value;
+use rmpv::{ext::to_value, Value};
+use serde::{self, Deserialize, Deserializer, Serialize};
 
 /// Pack the given arguments into a `Vec<Value>`, suitable for using it for a
 /// [`call`](crate::neovim::Neovim::call) to neovim.
 #[macro_export]
 macro_rules! call_args {
-    () => (Vec::new());
+    () => {
+        {
+            let vec: Vec<Value> = Vec::new();
+            vec
+        }
+    };
     ($($e:expr), +,) => (call_args![$($e),*]);
     ($($e:expr), +) => {{
         let mut vec = Vec::new();
@@ -96,17 +103,31 @@ where
     (req, fut)
   }
 
-  async fn send_msg(
+  /// Will panic if args is serialized into something that is not an array
+  async fn send_msg<T: Serialize + fmt::Debug>(
     &self,
     method: &str,
-    args: Vec<Value>,
+    args: T,
   ) -> Result<oneshot::Receiver<ResponseResult>, Box<EncodeError>> {
     let msgid = self.msgid_counter.fetch_add(1, Ordering::SeqCst);
+
+    fn get_args<T: Serialize + fmt::Debug>(
+      args: T,
+    ) -> Result<Vec<Value>, Box<EncodeError>> {
+      debug!("Args value is {:?}", args);
+      let args_value = to_value(args)?;
+      debug!("Args value is {:?}", args_value);
+
+      Ok(match args_value {
+        Value::Array(arr) => arr,
+        v => vec![v],
+      })
+    }
 
     let req = RpcMessage::RpcRequest {
       msgid,
       method: method.to_owned(),
-      params: args,
+      params: get_args(args)?,
     };
 
     let (sender, receiver) = oneshot::channel();
@@ -119,10 +140,10 @@ where
     Ok(receiver)
   }
 
-  pub async fn call(
+  pub async fn call<T: Serialize + fmt::Debug>(
     &self,
     method: &str,
-    args: Vec<Value>,
+    args: T,
   ) -> Result<Result<Value, Value>, Box<CallError>> {
     let receiver = self
       .send_msg(method, args)

--- a/src/neovim_api.rs
+++ b/src/neovim_api.rs
@@ -1,7 +1,10 @@
 //! The auto generated API for [`neovim`](crate::neovim::Neovim)
 //!
 //! Auto generated 2020-08-18 09:13:24.551223
+use std::fmt;
+
 use futures::io::AsyncWrite;
+use serde::Serialize;
 
 use crate::{
   error::CallError,
@@ -1009,13 +1012,17 @@ where
       .map_err(|v| Box::new(CallError::WrongValueType(v)))
   }
 
-  pub async fn call_function(
+  pub async fn call_function<T: Serialize + fmt::Debug>(
     &self,
     fname: &str,
-    args: Vec<Value>,
+    args: T,
   ) -> Result<Value, Box<CallError>> {
+
+    #[derive(Debug, Serialize)]
+    struct Args<'a, T: Serialize>(&'a str, T);
+
     self
-      .call("nvim_call_function", call_args![fname, args])
+      .call("nvim_call_function", Args(fname, args))
       .await??
       .try_unpack()
       .map_err(|v| Box::new(CallError::WrongValueType(v)))

--- a/src/rpc/model.rs
+++ b/src/rpc/model.rs
@@ -146,16 +146,6 @@ impl<'de> Deserialize<'de> for RpcMessage {
     deserializer.deserialize_seq(RpcVisitor)
   }
 }
-macro_rules! rpc_args {
-    ($($e:expr), *) => {{
-        let mut vec = Vec::new();
-        $(
-            vec.push(Value::from($e));
-        )*
-        Value::from(vec)
-    }}
-}
-
 /// Continously reads from reader, pushing onto `rest`. Then tries to decode the
 /// contents of `rest`. If it succeeds, returns the message, and leaves any
 /// non-decoded bytes in `rest`. If we did not read enough for a full message,


### PR DESCRIPTION
In your thoughts that you posted I saw that you wanted a strongly typed api and to hide `Value` from the user. I have implemented that using `rmp_serde` and the `with_serde` feature flag of `rmpv`. This allows `send_msg` to send anything with args that implement `Serialize` opening up possibilities for a strongly typed api because using structs as `args` will also work. This way `call` and `call_function` can both take a wide range of values also. The base of this pr is implementing `Serialize` and `Deserialize` for `RpcMessage`. Before you were manually serializing and deserializing into `RpcMessage`. Instead I have implemented the serde traits which is much easier and fits into the serde data model. Eventually I think that we don't need `Value` at all and can just rely on `serde`. This pr can open up very cool possibilities like having custom structs for common things like `CompleteItems` and `QfListItems`.

**Licensing**: The code contributed to nvim-rs is licensed under the MIT or
Apache license as given in the project root directory.