### PR TITLE
Remove the trailing slash of the submodule path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "neovim"]
 	path = neovim
-	url = https://github.com/neovim/neovim/
+	url = https://github.com/neovim/neovim
 	branch = master


### PR DESCRIPTION
For https links, the trailing slash is fine. But for users who have set `git config url.git@github.com:.insteadOf https://github.com/` this is problematic.

<!-- Your PR text here -->

**Licensing**: The code contributed to nvim-rs is licensed under the MIT or
Apache license as given in the project root directory.
