### PR TITLE
Add PartialEq/Eq to Neovim+exttypes, fix Clone impls, and add some nice macros

### DIFF
--- a/src/exttypes/buffer.rs
+++ b/src/exttypes/buffer.rs
@@ -15,18 +15,6 @@ where
 
 impl_exttype_traits!(Buffer);
 
-impl<W> Clone for Buffer<W>
-  where
-  W: AsyncWrite + Send + Unpin + 'static
-{
-  fn clone(&self) -> Self {
-    Self {
-      code_data: self.code_data.clone(),
-      neovim: self.neovim.clone(),
-    }
-  }
-}
-
 impl<W> IntoVal<Value> for &Buffer<W>
 where
   W: AsyncWrite + Send + Unpin + 'static,

--- a/src/exttypes/buffer.rs
+++ b/src/exttypes/buffer.rs
@@ -14,12 +14,3 @@ where
 }
 
 impl_exttype_traits!(Buffer);
-
-impl<W> IntoVal<Value> for &Buffer<W>
-where
-  W: AsyncWrite + Send + Unpin + 'static,
-{
-  fn into_val(self) -> Value {
-    self.code_data.clone()
-  }
-}

--- a/src/exttypes/buffer.rs
+++ b/src/exttypes/buffer.rs
@@ -1,7 +1,7 @@
 use futures::io::AsyncWrite;
 use rmpv::Value;
 
-use crate::{rpc::model::IntoVal, Neovim};
+use crate::{rpc::model::IntoVal, Neovim, impl_exttype_traits};
 /// A struct representing a neovim buffer. It is specific to a
 /// [`Neovim`](crate::neovim::Neovim) instance, and calling a method on it will
 /// always use this instance.
@@ -12,6 +12,8 @@ where
   pub(crate) code_data: Value,
   pub(crate) neovim: Neovim<W>,
 }
+
+impl_exttype_traits!(Buffer);
 
 impl<W> Clone for Buffer<W>
   where

--- a/src/exttypes/mod.rs
+++ b/src/exttypes/mod.rs
@@ -6,3 +6,20 @@ mod window;
 pub use buffer::Buffer;
 pub use tabpage::Tabpage;
 pub use window::Window;
+
+#[macro_export]
+macro_rules! impl_exttype_traits {
+  ($ext:ident) => {
+    impl<W> PartialEq for $ext<W>
+    where
+      W: AsyncWrite + Send + Unpin + 'static
+    {
+      fn eq(&self, other: &Self) -> bool {
+        self.code_data == other.code_data && self.neovim == other.neovim
+      }
+    }
+    impl<W> Eq for $ext<W>
+    where
+      W: AsyncWrite + Send + Unpin + 'static {}
+  }
+}

--- a/src/exttypes/mod.rs
+++ b/src/exttypes/mod.rs
@@ -33,5 +33,14 @@ macro_rules! impl_exttype_traits {
         }
       }
     }
+
+    impl<W> IntoVal<Value> for &$ext<W>
+    where
+      W: AsyncWrite + Send + Unpin + 'static,
+    {
+      fn into_val(self) -> Value {
+        self.code_data.clone()
+      }
+    }
   }
 }

--- a/src/exttypes/mod.rs
+++ b/src/exttypes/mod.rs
@@ -21,5 +21,17 @@ macro_rules! impl_exttype_traits {
     impl<W> Eq for $ext<W>
     where
       W: AsyncWrite + Send + Unpin + 'static {}
+
+    impl<W> Clone for $ext<W>
+    where
+      W: AsyncWrite + Send + Unpin + 'static
+    {
+      fn clone(&self) -> Self {
+        Self {
+          code_data: self.code_data.clone(),
+          neovim: self.neovim.clone(),
+        }
+      }
+    }
   }
 }

--- a/src/exttypes/tabpage.rs
+++ b/src/exttypes/tabpage.rs
@@ -6,7 +6,6 @@ use crate::{error::CallError, exttypes::Window, rpc::model::IntoVal, Neovim, imp
 /// A struct representing a neovim tabpage. It is specific to a
 /// [`Neovim`](crate::neovim::Neovim) instance, and calling a method on it will
 /// always use this instance.
-#[derive(Clone)]
 pub struct Tabpage<W>
 where
   W: AsyncWrite + Send + Unpin + 'static,

--- a/src/exttypes/tabpage.rs
+++ b/src/exttypes/tabpage.rs
@@ -1,7 +1,7 @@
 use futures::io::AsyncWrite;
 use rmpv::Value;
 
-use crate::{error::CallError, exttypes::Window, rpc::model::IntoVal, Neovim};
+use crate::{error::CallError, exttypes::Window, rpc::model::IntoVal, Neovim, impl_exttype_traits};
 
 /// A struct representing a neovim tabpage. It is specific to a
 /// [`Neovim`](crate::neovim::Neovim) instance, and calling a method on it will
@@ -14,6 +14,8 @@ where
   pub(crate) code_data: Value,
   pub(crate) neovim: Neovim<W>,
 }
+
+impl_exttype_traits!(Tabpage);
 
 impl<W> Tabpage<W>
 where

--- a/src/exttypes/tabpage.rs
+++ b/src/exttypes/tabpage.rs
@@ -51,12 +51,3 @@ where
     )
   }
 }
-
-impl<W> IntoVal<Value> for &Tabpage<W>
-where
-  W: AsyncWrite + Send + Unpin + 'static,
-{
-  fn into_val(self) -> Value {
-    self.code_data.clone()
-  }
-}

--- a/src/exttypes/window.rs
+++ b/src/exttypes/window.rs
@@ -7,7 +7,6 @@ use crate::{error::CallError, rpc::model::IntoVal, Neovim, impl_exttype_traits};
 /// A struct representing a neovim window. It is specific to a
 /// [`Neovim`](crate::neovim::Neovim) instance, and calling a method on it will
 /// always use this instance.
-#[derive(Clone)]
 pub struct Window<W>
 where
   W: AsyncWrite + Send + Unpin + 'static,

--- a/src/exttypes/window.rs
+++ b/src/exttypes/window.rs
@@ -2,7 +2,7 @@ use futures::io::AsyncWrite;
 use rmpv::Value;
 
 use super::{Buffer, Tabpage};
-use crate::{error::CallError, rpc::model::IntoVal, Neovim};
+use crate::{error::CallError, rpc::model::IntoVal, Neovim, impl_exttype_traits};
 
 /// A struct representing a neovim window. It is specific to a
 /// [`Neovim`](crate::neovim::Neovim) instance, and calling a method on it will
@@ -15,6 +15,8 @@ where
   pub(crate) code_data: Value,
   pub(crate) neovim: Neovim<W>,
 }
+
+impl_exttype_traits!(Window);
 
 impl<W> Window<W>
 where

--- a/src/exttypes/window.rs
+++ b/src/exttypes/window.rs
@@ -42,12 +42,3 @@ where
     )
   }
 }
-
-impl<W> IntoVal<Value> for &Window<W>
-where
-  W: AsyncWrite + Send + Unpin + 'static,
-{
-  fn into_val(self) -> Value {
-    self.code_data.clone()
-  }
-}

--- a/src/neovim.rs
+++ b/src/neovim.rs
@@ -67,6 +67,18 @@ where
   }
 }
 
+impl<W> PartialEq for Neovim<W>
+where
+  W: AsyncWrite + Send + Unpin + 'static,
+{
+  fn eq(&self, other: &Self) -> bool {
+    Arc::ptr_eq(&self.writer, &other.writer)
+  }
+}
+impl<W> Eq for Neovim<W>
+where
+  W: AsyncWrite + Send + Unpin + 'static {}
+
 impl<W> Neovim<W>
 where
   W: AsyncWrite + Send + Unpin + 'static,


### PR DESCRIPTION
This PR accomplishes a couple of things:

- Adding `PartialEq`/`Eq` to `Neovim` and all exttypes, and introduce a macro for implementing them called `impl_exttype_traits!`
- Move `Clone` implementations into `impl_extttype_traits!`, which drops the requirement on `<W>` needing a `Clone` implementation (which it really shouldn't, seeing as `<W>` gets wrapped by a container which does provide `Clone`)
- While we're at it, also move `Into<Value>` into `impl_exttype_traits!`, since it's the same for all exttypes

**Licensing**: The code contributed to nvim-rs is licensed under the MIT or
Apache license as given in the project root directory.
