### PR TITLE
Revert "Remove the trailing slash of the submodule path"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "neovim"]
 	path = neovim
-	url = https://github.com/neovim/neovim
+	url = https://github.com/neovim/neovim/
 	branch = master


### PR DESCRIPTION
Reverts KillTheMule/nvim-rs#20, since it broke the windows build.