### PR TITLE
Serialized event handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,10 @@ required-features = ["use_neovim_lib"]
 name = "scorched_earth_as"
 required-features = ["use_async-std"]
 
+[[example]]
+name = "nested_requests"
+required-features = ["use_tokio"]
+
 [[test]]
 name = "nested_requests"
 required-features = ["use_tokio"]
@@ -90,3 +94,7 @@ required-features = ["use_tokio"]
 [[test]]
 name = "connecting"
 path = "tests/connecting/mod.rs"
+
+[[test]]
+name = "notifications"
+required-features = ["use_tokio"]

--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,5 @@
 * Check what we're doing with outgoing request parameters, there are 2 allocations going on in call_args! and rpc_args!, and we're just reading it in the end.
 
 * Can we use the non-generic `split` methods from tokio for unixstream, tcpstream? Supposedly better performance, but introduces lifetimes...
+
+* Propogate errors from `model::encode()` in `handler_loop()`

--- a/examples/nested_requests.rs
+++ b/examples/nested_requests.rs
@@ -1,0 +1,175 @@
+use nvim_rs::{
+  compat::tokio::Compat,
+  create::tokio as create,
+  neovim::Neovim,
+  Handler,
+};
+
+use async_trait::async_trait;
+
+use rmpv::Value;
+
+use std::{
+  sync::Arc,
+  path::Path,
+};
+
+use tokio::{
+  self,
+  process::{ChildStdin, Command},
+  sync::Mutex,
+  spawn
+};
+
+const NVIM_BIN: &str = if cfg!(windows) {
+  "nvim.exe"
+} else {
+  "nvim"
+};
+const NVIM_PATH: &str = if cfg!(windows) {
+  "neovim/build/bin/nvim.exe"
+} else {
+  "neovim/build/bin/nvim"
+};
+
+#[derive(Clone)]
+struct NeovimHandler {
+  froodle: Arc<Mutex<String>>,
+}
+
+#[async_trait]
+impl Handler for NeovimHandler {
+  type Writer = Compat<ChildStdin>;
+
+  async fn handle_request(
+    &self,
+    name: String,
+    args: Vec<Value>,
+    neovim: Neovim<Compat<ChildStdin>>,
+  ) -> Result<Value, Value> {
+    match name.as_ref() {
+      "dummy" => Ok(Value::from("o")),
+      "req" => {
+        let v = args[0].as_str().unwrap();
+
+        let neovim = neovim.clone();
+        match v {
+          "y" => {
+            let mut x: String = neovim
+              .get_vvar("progname")
+              .await
+              .unwrap()
+              .as_str()
+              .unwrap()
+              .into();
+            x.push_str(" - ");
+            x.push_str(
+              neovim.get_var("oogle").await.unwrap().as_str().unwrap(),
+            );
+            x.push_str(" - ");
+            x.push_str(
+              neovim
+                .eval("rpcrequest(1,'dummy')")
+                .await
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            );
+            x.push_str(" - ");
+            x.push_str(
+              neovim
+                .eval("rpcrequest(1,'req', 'z')")
+                .await
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            );
+            Ok(Value::from(x))
+          }
+          "z" => {
+            let x: String = neovim
+              .get_vvar("progname")
+              .await
+              .unwrap()
+              .as_str()
+              .unwrap()
+              .into();
+            Ok(Value::from(x))
+          }
+          &_ => Err(Value::from("wrong argument to req")),
+        }
+      }
+      &_ => Err(Value::from("wrong method name for request")),
+    }
+  }
+
+  async fn handle_notify(
+    &self,
+    name: String,
+    args: Vec<Value>,
+    _neovim: Neovim<Compat<ChildStdin>>,
+  ) {
+    match name.as_ref() {
+      "set_froodle" => {
+        *self.froodle.lock().await = args[0].as_str().unwrap().to_string()
+      }
+      _ => {}
+    };
+  }
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+  let rs = r#"exe ":fun M(timer) 
+      call rpcnotify(1, 'set_froodle', rpcrequest(1, 'req', 'y'))
+    endfun""#;
+  let rs2 = r#"exe ":fun N(timer) 
+      call chanclose(1)
+    endfun""#;
+
+  let froodle = Arc::new(Mutex::new(String::new()));
+  let handler = NeovimHandler {
+    froodle: froodle.clone(),
+  };
+
+  let path = if Path::new(NVIM_PATH).exists() {
+    NVIM_PATH
+  } else {
+    NVIM_BIN
+  };
+  let (nvim, io, _child) = create::new_child_cmd(
+    Command::new(path).args(&[
+      "-u",
+      "NONE",
+      "--embed",
+      "--headless",
+      "-c",
+      rs,
+      "-c",
+      ":let timer = timer_start(500, 'M')",
+      "-c",
+      rs2,
+      "-c",
+      ":let timer = timer_start(1500, 'N')",
+    ]),
+    handler,
+  )
+  .await
+  .unwrap();
+
+  let nv = nvim.clone();
+  spawn(async move { nv.set_var("oogle", Value::from("doodle")).await });
+
+  // The 2nd timer closes the channel, which will be returned as an error from
+  // the io handler. We only fail the test if we got another error
+  if let Err(err) = io.await.unwrap() {
+    if !err.is_channel_closed() {
+      panic!("Error in io: '{:?}'", err);
+    }
+  }
+
+  assert_eq!(
+    format!("{nvim} - doodle - o - {nvim}", nvim = NVIM_BIN),
+    *froodle.lock().await
+  );
+}

--- a/src/rpc/handler.rs
+++ b/src/rpc/handler.rs
@@ -31,7 +31,9 @@ pub trait Handler: Send + Sync + Clone + 'static {
     Err(Value::from("Not implemented"))
   }
 
-  /// Handling an rpc notification.
+  /// Handling an rpc notification. Notifications are handled one at a time in
+  /// the order in which they were received, and will block new requests from
+  /// being received until handle_notify returns.
   async fn handle_notify(
     &self,
     _name: String,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,37 @@
+use std::{
+  path::PathBuf,
+  env,
+};
+
+#[allow(dead_code)]
+pub const NVIM_BIN: &str = if cfg!(windows) {
+  "nvim.exe"
+} else {
+  "nvim"
+};
+const NVIM_PATH: &str = if cfg!(windows) {
+  "neovim/build/bin/nvim.exe"
+} else {
+  "neovim/build/bin/nvim"
+};
+
+pub fn nvim_path() -> PathBuf {
+  let (path_str, have_env) = match env::var("NVIM_RS_TEST_BIN") {
+    Ok(path) => (path, true),
+    Err(_) => (NVIM_PATH.into(), false),
+  };
+
+  let path = PathBuf::from(&path_str);
+  if !path.exists() {
+    if have_env {
+      panic!("nvim bin from $NVIM_RS_TEST_BIN \"{}\" does not exist", path_str)
+    } else {
+      panic!(
+        "\"{}\" not found, maybe you need to build it or set \
+        $NVIM_RS_TEST_BIN?",
+        NVIM_PATH
+      );
+    }
+  }
+  path
+}

--- a/tests/connecting/conns.rs
+++ b/tests/connecting/conns.rs
@@ -21,10 +21,10 @@ use std::{
 #[cfg(unix)]
 use tempdir::TempDir;
 
-#[cfg(windows)]
-const NVIMPATH: &str = "neovim/build/bin/nvim.exe";
-#[cfg(unix)]
-const NVIMPATH: &str = "neovim/build/bin/nvim";
+#[path = "../common/mod.rs"]
+mod common;
+use common::*;
+
 const HOST: &str = "127.0.0.1";
 const PORT: u16 = 6666;
 
@@ -32,7 +32,7 @@ const PORT: u16 = 6666;
 async fn can_connect_via_tcp() {
   let listen = HOST.to_string() + ":" + &PORT.to_string();
 
-  let mut child = Command::new(NVIMPATH)
+  let mut child = Command::new(nvim_path())
     .args(&["-u", "NONE", "--headless", "--listen", &listen])
     .spawn()
     .expect("Cannot start neovim");
@@ -83,7 +83,7 @@ fn get_socket_path() -> (std::path::PathBuf, ()) {
 async fn can_connect_via_path() {
   let (socket_path, _guard) = get_socket_path();
 
-  let mut child = Command::new(NVIMPATH)
+  let mut child = Command::new(nvim_path())
     .args(&["-u", "NONE", "--headless"])
     .env("NVIM_LISTEN_ADDRESS", &socket_path)
     .spawn()

--- a/tests/nested_requests.rs
+++ b/tests/nested_requests.rs
@@ -16,7 +16,8 @@ use tokio::{
 
 use futures::lock::Mutex;
 
-const NVIMPATH: &str = "neovim/build/bin/nvim";
+mod common;
+use common::*;
 
 #[derive(Clone)]
 struct NeovimHandler {
@@ -119,7 +120,7 @@ async fn nested_requests() {
   };
 
   let (nvim, io_handler, _child) = create::new_child_cmd(
-    Command::new(NVIMPATH).args(&[
+    Command::new(nvim_path()).args(&[
       "-u",
       "NONE",
       "--embed",
@@ -149,5 +150,8 @@ async fn nested_requests() {
     }
   }
 
-  assert_eq!("nvim - doodle - o - nvim", *froodle.lock().await);
+  assert_eq!(
+    format!("{nvim} - doodle - o - {nvim}", nvim = NVIM_BIN),
+    *froodle.lock().await
+  );
 }

--- a/tests/notifications.rs
+++ b/tests/notifications.rs
@@ -1,0 +1,127 @@
+use std::{
+  sync::Arc,
+  time::Duration,
+};
+
+use async_trait::async_trait;
+
+use tokio::{
+  sync::{
+    mpsc::{UnboundedSender, unbounded_channel},
+    Notify,
+  },
+  process::{ChildStdin, Command},
+  task::yield_now,
+};
+
+use futures::FutureExt;
+
+use nvim_rs::{
+  self,
+  create::tokio as create,
+  compat::tokio::Compat,
+  neovim::Neovim,
+  Value,
+};
+
+mod common;
+use common::*;
+
+const ITERS: usize = 25;
+const TIMEOUT: Duration = Duration::from_secs(60);
+
+macro_rules! timeout {
+  ($x:expr) => {
+    tokio::time::timeout(TIMEOUT, $x).map(|res| {
+      res.expect(&format!("Timed out waiting for {}", stringify!($x)))
+    })
+  }
+}
+
+#[derive(Clone)]
+struct Handler {
+  result_sender: UnboundedSender<u8>,
+  notifiers: Arc<Vec<Notify>>,
+}
+
+#[async_trait]
+impl nvim_rs::Handler for Handler {
+  type Writer = Compat<ChildStdin>;
+
+  async fn handle_notify(
+    &self,
+    name: String,
+    args: Vec<Value>,
+    _: Neovim<Self::Writer>,
+  ) {
+    assert_eq!(name, "idx");
+    let idx = args[0].as_i64().unwrap();
+
+    /* Wait until we've received a message from the test, then send back the
+     * number we received.
+     */
+    self.notifiers[idx as usize].notified().await;
+    self.result_sender.send(idx as u8).unwrap();
+  }
+}
+
+#[tokio::test]
+async fn sequential_notifications() {
+  // Create a tokio notifier for each nvim notification that we'll be handling
+  let mut notifiers = Vec::<Notify>::with_capacity(ITERS);
+  for _ in 0..ITERS {
+    notifiers.push(Notify::new());
+  }
+  let notifiers = Arc::new(notifiers);
+
+  /* Create a channel the notification handler will use each time for writing
+   * back the number provided by each notification
+   */
+  let (result_sender, mut result_receiver) = unbounded_channel();
+  let handler = Handler {
+    result_sender,
+    notifiers: notifiers.clone(),
+  };
+
+  // Startup nvim
+  let (nvim, _io_handler, _child) = create::new_child_cmd(
+    Command::new(nvim_path()).args(&[
+      "-u",
+      "NONE",
+      "--embed",
+      "--headless",
+    ]),
+    handler
+  )
+  .await
+  .unwrap();
+
+  // Generate the commands to send the notifications
+  let mut nvim_cmds = Vec::<String>::with_capacity(ITERS);
+  for i in 0..ITERS {
+    nvim_cmds.push(format!("call rpcnotify(1, 'idx', {})", i));
+  }
+
+  /* Start sending the notifications. We use nvim.command() instead of passing
+   * the commands via -c on the command line so that we block the test until the
+   * notifications are actually pending.
+   */
+  timeout!(nvim.command(nvim_cmds.join("|").as_str())).await.unwrap();
+
+  /* Unblock notifications in the reverse order that they were sent, if
+   * notifications are being handled sequentially then they should still be
+   * processed in their original order.
+   */
+  for notifier in notifiers.iter().rev() {
+    notifier.notify_one();
+    /* Yield once, so that we guarantee the notification handler for this
+     * notification executes pre-maturely if it was handled out of order.
+     */
+    yield_now().await;
+  }
+
+  // Check the results
+  for i in 0..ITERS {
+    assert_eq!(i as u8, timeout!(result_receiver.recv()).await.unwrap());
+  }
+}


### PR DESCRIPTION
This is in response to the comments on #25 

Continuation of the work for serialized events. This also demonstrates how I was able to just combine the two futures we needed to run in parallel into one to make the interface simpler. Note that I've only tested this with my `neovim-gtk` fork so far, I'm going to try to make sure the nested requests example is still working hopefully this weekend and finish cleaning the rest of this up and implementing proper error handling.

Let me know what you think.