### PR TITLE
Cross platform path connections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,8 @@ parity-tokio-ipc = { version = "0.9.0", optional = true }
 
 [dev-dependencies]
 tempdir = "0.3"
+# TODO: if changing tempdir: the rand version is based on whatever version
+# tempdir is using, to deduplicate dependencies
 rand = "0.4.6"
 criterion = "0.3.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 edition = "2018"
 
 [features]
-use_tokio = ["tokio", "tokio-util"]
+use_tokio = ["tokio", "tokio-util", "parity-tokio-ipc"]
 use_async-std = ["async-std"]
 use_neovim_lib = ["neovim-lib"]
 
@@ -37,6 +37,7 @@ tokio = { version = "1.1.1", features = ["full"] , optional = true}
 tokio-util = { version = "0.6.3", features = ["compat"], optional = true }
 async-std = { version = "1.4.0", features = ["attributes"], optional = true }
 neovim-lib = { version = "0.6.1", optional = true }
+parity-tokio-ipc = { version = "0.9.0", optional = true }
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ parity-tokio-ipc = { version = "0.9.0", optional = true }
 
 [dev-dependencies]
 tempdir = "0.3"
+rand = "0.4.6"
 criterion = "0.3.0"
 
 [profile.bench]

--- a/src/create/async_std.rs
+++ b/src/create/async_std.rs
@@ -54,8 +54,9 @@ where
 }
 
 #[cfg(unix)]
-/// Connect to a neovim instance via unix socket
-pub async fn new_unix_socket<H, P: AsRef<Path> + Clone>(
+/// Connect to a neovim instance via unix socket by path. This is currently
+/// only available on Unix for async-std.
+pub async fn new_path<H, P: AsRef<Path> + Clone>(
   path: P,
   handler: H,
 ) -> io::Result<(

--- a/src/create/async_std.rs
+++ b/src/create/async_std.rs
@@ -8,9 +8,11 @@ use async_std::os::unix::net::UnixStream;
 use async_std::{
   io::{stdin, stdout, Stdout},
   net::{TcpStream, ToSocketAddrs},
-  path::Path,
   task::{spawn, JoinHandle},
 };
+
+#[cfg(unix)]
+use async_std::path::Path;
 
 use futures::io::{AsyncReadExt, WriteHalf};
 

--- a/tests/connecting/conns.rs
+++ b/tests/connecting/conns.rs
@@ -1,9 +1,9 @@
 use nvim_rs::rpc::handler::Dummy as DummyHandler;
 
 #[cfg(feature = "use_tokio")]
-use tokio::test as atest;
-#[cfg(feature = "use_tokio")]
 use nvim_rs::create::tokio as create;
+#[cfg(feature = "use_tokio")]
+use tokio::test as atest;
 
 #[cfg(feature = "use_async-std")]
 use async_std::test as atest;
@@ -92,7 +92,7 @@ async fn can_connect_via_unix_socket() {
   }
 
   let handler = DummyHandler::new();
-  let (nvim, _io_handle) = create::new_unix_socket(&socket_path, handler)
+  let (nvim, _io_handle) = create::new_path(&socket_path, handler)
     .await
     .expect(&format!(
       "Unable to connect to neovim's unix socket at {:?}",

--- a/tests/connecting/conns.rs
+++ b/tests/connecting/conns.rs
@@ -78,6 +78,7 @@ fn get_socket_path() -> (std::path::PathBuf, ()) {
   (name.into(), ())
 }
 
+#[cfg(not(all(feature = "use_async-std", windows)))]
 #[atest]
 async fn can_connect_via_path() {
   let (socket_path, _guard) = get_socket_path();

--- a/tests/connecting/conns.rs
+++ b/tests/connecting/conns.rs
@@ -17,10 +17,11 @@ use std::{
 };
 
 #[cfg(unix)]
-use std::path::Path;
-#[cfg(unix)]
 use tempdir::TempDir;
 
+#[cfg(windows)]
+const NVIMPATH: &str = "neovim/build/bin/nvim.exe";
+#[cfg(unix)]
 const NVIMPATH: &str = "neovim/build/bin/nvim";
 const HOST: &str = "127.0.0.1";
 const PORT: u16 = 6666;
@@ -61,12 +62,24 @@ async fn can_connect_via_tcp() {
 }
 
 #[cfg(unix)]
-#[atest]
-async fn can_connect_via_unix_socket() {
+fn get_socket_path() -> (PathBuf, TempDir) {
   let dir = TempDir::new("neovim-lib.test")
     .expect("Cannot create temporary directory for test.");
 
-  let socket_path = dir.path().join("unix_socket");
+  (dir.path().join("unix_socket"), dir)
+}
+
+// tests using this only run on windows + tokio
+#[cfg(all(windows, feature = "use_tokio"))]
+fn get_socket_path() -> (std::path::PathBuf, ()) {
+  let rand = rand::random::<u32>();
+  let name = format!(r"\\.\pipe\nvim-rs-test-{}", rand);
+  (name.into(), ())
+}
+
+#[cfg(not(any(feature = "use_tokio", windows)))]
+async fn can_connect_via_unix() {
+  let (socket_path, _guard) = get_socket_path();
 
   let mut child = Command::new(NVIMPATH)
     .args(&["-u", "NONE", "--headless"])
@@ -86,13 +99,13 @@ async fn can_connect_via_unix_socket() {
       }
 
       if one_second <= start.elapsed() {
-        panic!(format!("neovim socket not found at '{:?}'", &socket_path));
+        panic!("neovim socket not found at '{:?}'", &socket_path);
       }
     }
   }
 
   let handler = DummyHandler::new();
-  let (nvim, _io_handle) = create::new_path(&socket_path, handler)
+  let (nvim, _io_handle) = create::tokio::new_unix(&socket_path, handler)
     .await
     .expect(&format!(
       "Unable to connect to neovim's unix socket at {:?}",
@@ -110,4 +123,59 @@ async fn can_connect_via_unix_socket() {
   child.kill().expect("Could not kill neovim");
 
   assert_eq!(socket_path, Path::new(&servername));
+}
+
+#[cfg(feature = "use_tokio")]
+mod path_tests {
+  use super::*;
+  use std::path::Path;
+
+  #[atest]
+  async fn can_connect_via_path() {
+    let (socket_path, _guard) = get_socket_path();
+
+    let mut child = Command::new(NVIMPATH)
+      .args(&["-u", "NONE", "--headless"])
+      .env("NVIM_LISTEN_ADDRESS", &socket_path)
+      .spawn()
+      .expect("Cannot start neovim");
+
+    // wait at most 1 second for neovim to start and create the socket
+    {
+      let start = Instant::now();
+      let one_second = Duration::from_secs(1);
+      loop {
+        sleep(Duration::from_millis(100));
+
+        if let Ok(_) = std::fs::metadata(&socket_path) {
+          break;
+        }
+
+        if one_second <= start.elapsed() {
+          panic!("neovim socket not found at '{:?}'", &socket_path);
+        }
+      }
+    }
+
+    let handler = DummyHandler::new();
+    let (nvim, _io_handle) =
+      nvim_rs::create::tokio::new_path(&socket_path, handler)
+        .await
+        .expect(&format!(
+          "Unable to connect to neovim's unix socket at {:?}",
+          &socket_path
+        ));
+
+    let servername = nvim
+      .get_vvar("servername")
+      .await
+      .expect("Error retrieving servername from neovim")
+      .as_str()
+      .unwrap()
+      .to_string();
+
+    child.kill().expect("Could not kill neovim");
+
+    assert_eq!(socket_path, Path::new(&servername));
+  }
 }


### PR DESCRIPTION
<!-- Your PR text here -->
Neovim uses either a named pipe at `\\.\pipe\nvim-numbers-morenumbers` on Windows, or various paths of a Unix socket on Unices. Previously this crate only supported dealing with Unix sockets, so Windows users wanting to connect to the `NVIM_LISTEN_ADDRESS` of the parent neovim process were SOL.

This PR uses `parity-tokio-ipc` to deal with abstracting over those two transports on the respective operating systems, keeping the code of this library basically exactly the same.

**Breaking change**: `create::tokio::new_unix` is now `create::tokio::new_path`, and that function also works on Windows now.

**Licensing**: The code contributed to nvim-rs is licensed under the MIT or
Apache license as given in the project root directory.
