### PR TITLE
Drop unneeded mut qualifiers on API

### DIFF
--- a/src/neovim.rs
+++ b/src/neovim.rs
@@ -293,7 +293,7 @@ where
   ///
   /// After this method is called, the client will receive redraw notifications.
   pub async fn ui_attach(
-    &mut self,
+    &self,
     width: i64,
     height: i64,
     opts: &UiAttachOptions,
@@ -310,7 +310,7 @@ where
   /// Send a quit command to Nvim.
   /// The quit command is 'qa!' which will make Nvim quit without
   /// saving anything.
-  pub async fn quit_no_save(&mut self) -> Result<(), Box<CallError>> {
+  pub async fn quit_no_save(&self) -> Result<(), Box<CallError>> {
     self.command("qa!").await
   }
 }


### PR DESCRIPTION
Just something I noticed the other day - `Neovim<W>::ui_attach` and
`Neovim<W>::quit_no_save` require self be mutable but never actually modify
it. So, let's fix that.

**Licensing**: The code contributed to nvim-rs is licensed under the MIT or
Apache license as given in the project root directory.
