### PR TITLE
deploy docs on github pages

### DIFF
--- a/.github/workflows/doc.sh
+++ b/.github/workflows/doc.sh
@@ -1,0 +1,7 @@
+mkdir doc
+RUSTDOCFLAGS="--cfg docsrs" cargo doc --features use_tokio --no-deps
+mv target/doc/ doc/use_tokio
+RUSTDOCFLAGS="--cfg docsrs" cargo doc --features use_async-std --no-deps
+mv target/doc/ doc/use_async-std
+RUSTDOCFLAGS="--cfg docsrs" cargo doc --features use_neovim_lib --no-deps
+mv target/doc/ doc/use_neovim_lib

--- a/.github/workflows/doc.sh
+++ b/.github/workflows/doc.sh
@@ -3,5 +3,3 @@ RUSTDOCFLAGS="--cfg docsrs" cargo doc --features use_tokio --no-deps
 mv target/doc/ doc/use_tokio
 RUSTDOCFLAGS="--cfg docsrs" cargo doc --features use_async-std --no-deps
 mv target/doc/ doc/use_async-std
-RUSTDOCFLAGS="--cfg docsrs" cargo doc --features use_neovim_lib --no-deps
-mv target/doc/ doc/use_neovim_lib

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,33 @@
+name: Doc-Deploy
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          override: true
+
+      - name: Generate docs
+        run: sh .github/workflows/doc.sh
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./doc
+          force_orphan: true
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+          commit_message: ${{ github.event.head_commit.message  }}

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,4 +1,4 @@
-name: Doc-Deploy
+name: Doc
 
 on:
   push:
@@ -25,9 +25,10 @@ jobs:
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # github_token: ${{ secrets.GITHUB_TOKEN }}
+          # user_name: 'github-actions[bot]'
+          # user_email: 'github-actions[bot]@users.noreply.github.com'
+          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           publish_dir: ./doc
           force_orphan: true
-          user_name: 'github-actions[bot]'
-          user_email: 'github-actions[bot]@users.noreply.github.com'
           commit_message: ${{ github.event.head_commit.message  }}

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -3,8 +3,6 @@ name: Doc
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
 
 jobs:
   deploy:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+/doc

--- a/src/create/mod.rs
+++ b/src/create/mod.rs
@@ -11,7 +11,6 @@
 //! E.g. when using the features `use_tokio`, you will need to run all the
 //! API functions from inside the tokio runtime.
 #[cfg(feature = "use_tokio")]
-#[cfg_attr(docsrs, doc(cfg(feature = "use_tokio")))]
 pub mod tokio;
 
 #[cfg(feature = "use_async-std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //!
 //! I've not yet worked through the details of what-to-export, but I'm quite
 //! willing to consider what people need or want.
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 extern crate rmp;
 extern crate rmpv;
 #[macro_use]
@@ -48,9 +48,8 @@ pub use crate::{
 };
 
 #[cfg(feature = "use_tokio")]
-#[cfg_attr(docsrs, doc(cfg(feature = "use_tokio")))]
 pub mod compat {
-  //! A re-export of tokio-util's [`Compat`](tokio_util::compat::Compat) 
+  //! A re-export of tokio-util's [`Compat`](tokio_util::compat::Compat)
   pub mod tokio {
     pub use tokio_util::compat::Compat;
   }


### PR DESCRIPTION
This PR is very simple and may help to show docs under distinct and incompatible features, which is related to #36.


| feature        | deployed doc  sample                                                     |
|----------------|--------------------------------------------------------------------|
| use_tokio      | https://zjp-cn.github.io/nvim-rs/use_tokio/nvim_rs      |
| use_async-std  | https://zjp-cn.github.io/nvim-rs/use_async-std/nvim_rs  |


Note:
This will create a `gh-pages` branch, and you have to set the source:
![image](https://user-images.githubusercontent.com/25300418/159853751-307af30b-1ba9-4fc0-aac3-332c3cadf2d0.png)
The generated files look like [these](https://github.com/zjp-CN/nvim-rs/tree/gh-pages).

---

**Licensing**: The code contributed to nvim-rs is licensed under the MIT or
Apache license as given in the project root directory.
