### PR TITLE
Update the UI options

### DIFF
--- a/src/uioptions.rs
+++ b/src/uioptions.rs
@@ -6,15 +6,22 @@ use rmpv::Value;
 
 pub enum UiOption {
   Rgb(bool),
+  Override(bool),
+  ExtCmdline(bool),
+  ExtHlstate(bool),
+  ExtLinegrid(bool),
+  ExtMessages(bool),
+  ExtMultigrid(bool),
   ExtPopupmenu(bool),
   ExtTabline(bool),
-  ExtCmdline(bool),
-  ExtWildmenu(bool),
-  ExtLinegrid(bool),
-  ExtHlstate(bool),
-  ExtMultigrid(bool),
-  ExtMessages(bool),
   ExtTermcolors(bool),
+  TermName(String),
+  TermColors(u64),
+  TermBackground(String),
+  StdinFd(u64),
+  StdinTty(bool),
+  StdoutTty(bool),
+  ExtWildmenu(bool),
 }
 
 impl UiOption {
@@ -24,17 +31,24 @@ impl UiOption {
   }
 
   fn to_name_value(&self) -> (&'static str, Value) {
-    match *self {
-      Self::Rgb(val) => ("rgb", val.into()),
-      Self::ExtPopupmenu(val) => ("ext_popupmenu", val.into()),
-      Self::ExtTabline(val) => ("ext_tabline", val.into()),
-      Self::ExtCmdline(val) => ("ext_cmdline", val.into()),
-      Self::ExtWildmenu(val) => ("ext_wildmenu", val.into()),
-      Self::ExtLinegrid(val) => ("ext_linegrid", val.into()),
-      Self::ExtHlstate(val) => ("ext_hlstate", val.into()),
-      Self::ExtMultigrid(val) => ("ext_multigrid", val.into()),
-      Self::ExtMessages(val) => ("ext_messages", val.into()),
-      Self::ExtTermcolors(val) => ("ext_termcolors", val.into()),
+    match self {
+      Self::Rgb(val) => ("rgb", (*val).into()),
+      Self::Override(val) => ("override", (*val).into()),
+      Self::ExtCmdline(val) => ("ext_cmdline", (*val).into()),
+      Self::ExtHlstate(val) => ("ext_hlstate", (*val).into()),
+      Self::ExtLinegrid(val) => ("ext_linegrid", (*val).into()),
+      Self::ExtMessages(val) => ("ext_messages", (*val).into()),
+      Self::ExtMultigrid(val) => ("ext_multigrid", (*val).into()),
+      Self::ExtPopupmenu(val) => ("ext_popupmenu", (*val).into()),
+      Self::ExtTabline(val) => ("ext_tabline", (*val).into()),
+      Self::ExtTermcolors(val) => ("ext_termcolors", (*val).into()),
+      Self::TermName(val) => ("term_name", val.as_str().into()),
+      Self::TermColors(val) => ("term_colors", (*val).into()),
+      Self::TermBackground(val) => ("term_background", val.as_str().into()),
+      Self::StdinFd(val) => ("stdin_fd", (*val).into()),
+      Self::StdinTty(val) => ("stdin_tty", (*val).into()),
+      Self::StdoutTty(val) => ("stdout_tty", (*val).into()),
+      Self::ExtWildmenu(val) => ("ext_wildmenu", (*val).into()),
     }
   }
 }
@@ -45,11 +59,11 @@ pub struct UiAttachOptions {
 }
 
 macro_rules! ui_opt_setters {
-  ($( $opt:ident as $set:ident );+ ;) => {
+  ($( $opt:ident as $set:ident($type:ty) );+ ;) => {
     impl UiAttachOptions {
       $(
-        pub fn $set(&mut self, val: bool) -> &mut Self {
-          self.set_option(UiOption::$opt(val));
+        pub fn $set(&mut self, val: $type) -> &mut Self {
+          self.set_option(UiOption::$opt(val.into()));
           self
         }
       )+
@@ -58,16 +72,24 @@ macro_rules! ui_opt_setters {
 }
 
 ui_opt_setters! (
-  Rgb as set_rgb;
-  ExtPopupmenu as set_popupmenu_external;
-  ExtTabline as set_tabline_external;
-  ExtCmdline as set_cmdline_external;
-  ExtWildmenu as set_wildmenu_external;
-  ExtLinegrid as set_linegrid_external;
-  ExtHlstate as set_hlstate_external;
-  ExtMultigrid as set_multigrid_external;
-  ExtMessages as set_messages_external;
-  ExtTermcolors as set_termcolors_external;
+
+  Rgb as set_rgb(bool);
+  Override as set_override(bool);
+  ExtCmdline as set_cmdline_external(bool);
+  ExtHlstate as set_hlstate_external(bool);
+  ExtLinegrid as set_linegrid_external(bool);
+  ExtMessages as set_messages_externa(bool);
+  ExtMultigrid as set_multigrid_external(bool);
+  ExtPopupmenu as set_popupmenu_external(bool);
+  ExtTabline as set_tabline_external(bool);
+  ExtTermcolors as set_termcolors_external(bool);
+  TermName as set_term_name(&str);
+  TermColors as set_term_colors(u64);
+  TermBackground as set_term_background(&str);
+  StdinFd as set_stdin_fd(u64);
+  StdinTty as set_stdin_tty(bool);
+  StdoutTty as set_stdout_tty(bool);
+  ExtWildmenu as set_wildmenu_external(bool);
 );
 
 impl UiAttachOptions {


### PR DESCRIPTION
Update the UI options to match the latest 0.9.2 Neovim release. 

We would like to use `TermBackground` in Neovide, so it would be great if a new release could be made supporting these options.