### PR TITLE
Nobufw

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 
 use rmpv::Value;
 
-use tokio::io::Stdout;
+use tokio::fs::File as TokioFile;
 
 use nvim_rs::{
   compat::tokio::Compat, create::tokio as create, rpc::IntoVal, Handler, Neovim,
@@ -17,13 +17,13 @@ struct NeovimHandler {}
 
 #[async_trait]
 impl Handler for NeovimHandler {
-  type Writer = Compat<Stdout>;
+  type Writer = Compat<TokioFile>;
 
   async fn handle_request(
     &self,
     name: String,
     _args: Vec<Value>,
-    _neovim: Neovim<Compat<Stdout>>,
+    _neovim: Neovim<Compat<TokioFile>>,
   ) -> Result<Value, Value> {
     match name.as_ref() {
       "ping" => Ok(Value::from("pong")),
@@ -35,7 +35,7 @@ impl Handler for NeovimHandler {
 #[tokio::main]
 async fn main() {
   let handler: NeovimHandler = NeovimHandler {};
-  let (nvim, io_handler) = create::new_parent(handler).await;
+  let (nvim, io_handler) = create::new_parent(handler).await.unwrap();
   let curbuf = nvim.get_current_buf().await.unwrap();
 
   let mut envargs = env::args();

--- a/examples/scorched_earth.rs
+++ b/examples/scorched_earth.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use rmpv::Value;
 
 use futures::lock::Mutex;
-use tokio::io::Stdout;
+use tokio::fs::File as TokioFile;
 
 use nvim_rs::{
   compat::tokio::Compat, create::tokio as create, Handler, Neovim,
@@ -44,13 +44,13 @@ struct NeovimHandler(Arc<Mutex<Posis>>);
 
 #[async_trait]
 impl Handler for NeovimHandler {
-  type Writer = Compat<Stdout>;
+  type Writer = Compat<TokioFile>;
 
   async fn handle_notify(
     &self,
     name: String,
     args: Vec<Value>,
-    neovim: Neovim<Compat<Stdout>>,
+    neovim: Neovim<Compat<TokioFile>>,
   ) {
     match name.as_ref() {
       "cursor-moved-i" => {
@@ -102,7 +102,7 @@ async fn main() {
   };
   let handler: NeovimHandler = NeovimHandler(Arc::new(Mutex::new(p)));
 
-  let (nvim, io_handler) = create::new_parent(handler).await;
+  let (nvim, io_handler) = create::new_parent(handler).await.unwrap();
 
   // Any error should probably be logged, as stderr is not visible to users.
   match io_handler.await {

--- a/src/create/async_std.rs
+++ b/src/create/async_std.rs
@@ -1,15 +1,15 @@
 //! Functions to spawn a [`neovim`](crate::neovim::Neovim) session using
 //! [`async-std`](async-std)
-use std::{future::Future, io, fs::File, os::fd::AsFd};
+use std::{fs::File, future::Future, io, os::fd::AsFd};
 
 #[cfg(unix)]
 use async_std::os::unix::net::UnixStream;
 
 use async_std::{
-  io::{stdin},
+  fs::File as ASFile,
+  io::stdin,
   net::{TcpStream, ToSocketAddrs},
   task::{spawn, JoinHandle},
-  fs::File as ASFile,
 };
 
 #[cfg(unix)]

--- a/src/create/tokio.rs
+++ b/src/create/tokio.rs
@@ -1,21 +1,21 @@
 //! Functions to spawn a [`neovim`](crate::neovim::Neovim) session using
 //! [`tokio`](tokio)
 use std::{
+  fs::File,
   future::Future,
-  io::{self, Error, ErrorKind, stdout},
+  io::{self, stdout, Error, ErrorKind},
+  os::fd::AsFd,
   path::Path,
   process::Stdio,
-  fs::File,
-  os::fd::AsFd,
 };
 
 use tokio::{
+  fs::File as TokioFile,
   io::{split, stdin, WriteHalf},
   net::{TcpStream, ToSocketAddrs},
   process::{Child, ChildStdin, Command},
   spawn,
   task::JoinHandle,
-  fs::File as TokioFile,
 };
 
 use parity_tokio_ipc::{Connection, Endpoint};
@@ -155,10 +155,13 @@ where
 /// Connect to the neovim instance that spawned this process over stdin/stdout
 pub async fn new_parent<H>(
   handler: H,
-) -> Result<(
-  Neovim<Compat<tokio::fs::File>>,
-  JoinHandle<Result<(), Box<LoopError>>>,
-), Error>
+) -> Result<
+  (
+    Neovim<Compat<tokio::fs::File>>,
+    JoinHandle<Result<(), Box<LoopError>>>,
+  ),
+  Error,
+>
 where
   H: Handler<Writer = Compat<tokio::fs::File>>,
 {

--- a/src/neovim.rs
+++ b/src/neovim.rs
@@ -12,7 +12,7 @@ use futures::{
     mpsc::{unbounded, UnboundedReceiver, UnboundedSender},
     oneshot,
   },
-  io::{AsyncRead, AsyncWrite, BufWriter},
+  io::{AsyncRead, AsyncWrite,},
   lock::Mutex,
   sink::SinkExt,
   stream::StreamExt,
@@ -54,7 +54,7 @@ pub struct Neovim<W>
 where
   W: AsyncWrite + Send + Unpin + 'static,
 {
-  pub(crate) writer: Arc<Mutex<BufWriter<W>>>,
+  pub(crate) writer: Arc<Mutex<W>>,
   pub(crate) queue: Queue,
   pub(crate) msgid_counter: Arc<AtomicU64>,
 }
@@ -100,7 +100,7 @@ where
     H: Handler<Writer = W> + Spawner,
   {
     let req = Neovim {
-      writer: Arc::new(Mutex::new(BufWriter::new(writer))),
+      writer: Arc::new(Mutex::new(writer)),
       msgid_counter: Arc::new(AtomicU64::new(0)),
       queue: Arc::new(Mutex::new(Vec::new())),
     };

--- a/src/rpc/model.rs
+++ b/src/rpc/model.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use futures::{
-  io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufWriter},
+  io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt,},
   lock::Mutex,
 };
 use rmpv::{decode::read_value, encode::write_value, Value};
@@ -165,7 +165,7 @@ fn decode_buffer<R: Read>(
 /// Encode the given message into the `BufWriter`. Flushes the writer when
 /// finished.
 pub async fn encode<W: AsyncWrite + Send + Unpin + 'static>(
-  writer: Arc<Mutex<BufWriter<W>>>,
+  writer: Arc<Mutex<W>>,
   msg: RpcMessage,
 ) -> std::result::Result<(), Box<EncodeError>> {
   let mut v: Vec<u8> = vec![];


### PR DESCRIPTION
Constructs our own stdout, so we don't have line buffering anymore.

Also removes the bufwriter, it's not needed since we write_all and flush  each message anyways.

**Licensing**: The code contributed to nvim-rs is licensed under the MIT or
Apache license as given in the project root directory.
