### PR TITLE
Use tokio UnixStream / NamedPipeClient API instead of parity-tokio-ipc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 edition = "2021"
 
 [features]
-use_tokio = ["tokio", "tokio-util", "parity-tokio-ipc"]
+use_tokio = ["tokio", "tokio-util"]
 use_async-std = ["async-std"]
 use_neovim_lib = ["neovim-lib"]
 
@@ -37,14 +37,10 @@ rmpv = "1.0.1"
 log = "0.4.20"
 async-trait = "0.1.77"
 futures = { version = "0.3.30", features = ["io-compat"] }
-tokio = { version = "1.36.0", features = ["full"] , optional = true}
+tokio = { version = "1.36.0", features = ["full", "net"] , optional = true}
 tokio-util = { version = "0.7.10", features = ["compat"], optional = true }
 async-std = { version = "1.12.0", features = ["attributes"], optional = true }
 neovim-lib = { version = "0.6.1", optional = true }
-parity-tokio-ipc = { version = "0.9.0", optional = true }
-
-[target.'cfg(windows)'.dependencies]
-winapi = { version = '0.3.9', features = ["winerror"] }
 
 [dev-dependencies]
 tempfile = "3.9.0"


### PR DESCRIPTION
Fixes https://github.com/KillTheMule/nvim-rs/issues/49

<!-- Your PR text here -->

**Licensing**: The code contributed to nvim-rs is licensed under the MIT or
Apache license as given in the project root directory.
