### PR TITLE
Remove unused `io-compat` feature from `futures` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ bench = false
 rmp = "0.8.14"
 rmpv = "1.3.0"
 log = "0.4.26"
-futures = { version = "0.3.31", features = ["io-compat"] }
+futures = "0.3.31"
 tokio = { version = "1.43.0", features = ["full", "net"] , optional = true}
 tokio-util = { version = "0.7.13", features = ["compat"], optional = true }
 async-std = { version = "1.13.0", features = ["attributes"], optional = true }


### PR DESCRIPTION
Fix #59 

This PR drops the `io-compat` feature from `futures` crate dependency. I checked which crate/feature depended on the unmaintained `tokio-io` crate and found that `io-compat` depended on it. And as far as I checked, nvim-rs actually does not depend on the `io-compat` feature. nvim-rs depends on the tokio compatibility layer for `use_tokio` feature, but it is already enabled via `compat` faeture of `tokio-util` crate.

I confirmed all tests passed with this change and my own app depending on this crate worked fine. I confirmed `tokio-io` is no longer reported by `cargo audit` as well.

**Licensing**: The code contributed to nvim-rs is licensed under the MIT or
Apache license as given in the project root directory.
